### PR TITLE
Separate browser login from Control API auth

### DIFF
--- a/rewards-dashboard/.env.example
+++ b/rewards-dashboard/.env.example
@@ -9,10 +9,15 @@
 #   both on one machine  ->  http://127.0.0.1:3010
 CONTROL_API_URL=http://127.0.0.1:3010
 
-# The one shared authentication token. It must exactly match the Control API's
-# API_TOKEN. When set, it protects every dashboard request and is also sent to
-# the Control API. Leave both values empty to disable authentication.
+# Token used only when the dashboard connects to the Control API. It must
+# exactly match the Control API's API_TOKEN. Leave it empty only when the
+# Control API also runs without an API_TOKEN.
 CONTROL_API_TOKEN=
+
+# Optional browser login. Authentication is enabled only when BOTH values are
+# non-empty. Leave either value empty to allow access without a login prompt.
+DASHBOARD_USERNAME=
+DASHBOARD_PASSWORD=
 
 # --- optional ---------------------------------------------------------------
 

--- a/rewards-dashboard/Dockerfile
+++ b/rewards-dashboard/Dockerfile
@@ -17,6 +17,6 @@ RUN mkdir -p /data
 EXPOSE 8890
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD node -e "const t=process.env.CONTROL_API_TOKEN;const headers=t?{Authorization:'Basic '+Buffer.from('dashboard:'+t).toString('base64')}:{};fetch('http://127.0.0.1:8890/api/health',{headers}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+    CMD node -e "const u=process.env.DASHBOARD_USERNAME||'';const p=process.env.DASHBOARD_PASSWORD||'';const headers=u&&p?{Authorization:'Basic '+Buffer.from(u+':'+p).toString('base64')}:{};fetch('http://127.0.0.1:8890/api/health',{headers}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["node", "server.js"]

--- a/rewards-dashboard/README.md
+++ b/rewards-dashboard/README.md
@@ -32,16 +32,20 @@ cp .env.example .env      # edit CONTROL_API_URL + CONTROL_API_TOKEN
 npm start                 # http://localhost:8890
 ```
 
-There is one shared authentication token. Set `API_TOKEN` on the Control API
-and set `CONTROL_API_TOKEN` to the exact same value on the dashboard. When it
-is set, every dashboard page/API request and every Control API endpoint requires
-that token; browsers display their normal Basic-auth prompt. If both values are
-unset, authentication is disabled on both sides.
+Dashboard login protection is configured separately with `DASHBOARD_USERNAME`
+and `DASHBOARD_PASSWORD`. Basic authentication is enabled only when both values
+are non-empty. Leave either one empty to open the dashboard without a browser
+login prompt. This does not disable authentication between the dashboard and the
+Control API; `CONTROL_API_TOKEN` still needs to match the API's `API_TOKEN`.
 
 Or with Docker, from the parent directory:
 
 ```bash
-echo "CONTROL_API_TOKEN=some-long-random-string" > .env
+cat > .env <<'EOF'
+CONTROL_API_TOKEN=some-long-random-string
+DASHBOARD_USERNAME=admin
+DASHBOARD_PASSWORD=use-a-different-long-password
+EOF
 docker compose up -d --build
 ```
 
@@ -86,7 +90,7 @@ Above the tabs, a control strip is always visible: **Start**, **Stop**, **Restar
 
 **Live points.** The bot prints its balance and every gain as it earns them, and the API folds those lines into a running tally (`GET /points`). So the Overview shows points climbing _during_ a run, not just the final total. When an account finishes, the live tally is replaced by the authoritative `ACCOUNT-END` numbers.
 
-**One token protects both services.** The browser authenticates to the dashboard with the shared token, and the dashboard sends that same value to the Control API as a Bearer token. Configure it as `API_TOKEN` on the API and `CONTROL_API_TOKEN` on the dashboard.
+**Separate authentication layers.** `CONTROL_API_TOKEN` is sent only from the dashboard to the Control API as a Bearer token and must match the API's `API_TOKEN`. Browser access uses the optional `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` pair instead.
 
 **No dependencies.** Charts are hand-rolled inline SVG (`public/charts.js`) that read their colors from CSS variables, so they follow the theme and work offline. The 14 themes from the original dashboard are untouched.
 
@@ -94,16 +98,18 @@ Above the tabs, a control strip is always visible: **Start**, **Stop**, **Restar
 
 ## Environment
 
-| Variable            | Default                                |                                                                                           |
-| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `CONTROL_API_URL`   | `http://microsoft-rewards-script:3010` | Where the Control API listens                                                             |
-| `CONTROL_API_TOKEN` | -                                      | Shared token protecting the dashboard; must match the API's `API_TOKEN`                   |
-| `PORT`              | `8890`                                 |                                                                                           |
-| `TZ`                | `UTC`                                  | Buckets points into days - set it                                                         |
-| `DASHBOARD_TITLE`   | `Microsoft Rewards`                    | Header title                                                                              |
-| `POLL_MS`           | `5000`                                 | Status poll interval (logs are streamed)                                                  |
-| `LOG_REPLAY`        | `300`                                  | Log lines to replay when the stream connects                                              |
-| `DATA_DIR`          | `./data`                               | Where `dashboard.sqlite` lives - the only folder anything writes to. Docker sets `/data`. |
+| Variable              | Default                                |                                                                                           |
+| --------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `CONTROL_API_URL`     | `http://microsoft-rewards-script:3010` | Where the Control API listens                                                             |
+| `CONTROL_API_TOKEN`   | -                                      | Bearer token sent to the Control API; must match the API's `API_TOKEN`                    |
+| `DASHBOARD_USERNAME`  | -                                      | Optional Basic-auth username; auth is enabled only when username and password are set     |
+| `DASHBOARD_PASSWORD`  | -                                      | Optional Basic-auth password; leave either dashboard credential empty to disable login    |
+| `PORT`                | `8890`                                 |                                                                                           |
+| `TZ`                  | `UTC`                                  | Buckets points into days - set it                                                         |
+| `DASHBOARD_TITLE`     | `Microsoft Rewards`                    | Header title                                                                              |
+| `POLL_MS`             | `5000`                                 | Status poll interval (logs are streamed)                                                  |
+| `LOG_REPLAY`          | `300`                                  | Log lines to replay when the stream connects                                              |
+| `DATA_DIR`            | `./data`                               | Where `dashboard.sqlite` lives - the only folder anything writes to. Docker sets `/data`. |
 
 ---
 
@@ -112,6 +118,8 @@ Above the tabs, a control strip is always visible: **Start**, **Stop**, **Restar
 **"Control API unreachable"** - the dashboard can't open a TCP connection. Check `CONTROL_API_URL`. In Docker, `localhost` means the dashboard's own container: use the API's service name, or `host.docker.internal` with `extra_hosts`.
 
 **"Control API rejected our token"** - `CONTROL_API_TOKEN` ≠ `API_TOKEN`.
+
+**Browser login prompt does not appear** - both `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` must be non-empty. Authentication is intentionally disabled when either value is empty.
 
 **Saving config returns 403** - the API was started without `API_ALLOW_CONFIG_WRITE=true`.
 

--- a/rewards-dashboard/server.js
+++ b/rewards-dashboard/server.js
@@ -21,6 +21,11 @@ const PORT = Number(process.env.PORT || 8890);
 const CONTROL_API_URL =
   process.env.CONTROL_API_URL || "http://microsoft-rewards-script:3010";
 const CONTROL_API_TOKEN = process.env.CONTROL_API_TOKEN || "";
+const DASHBOARD_USERNAME = process.env.DASHBOARD_USERNAME || "";
+const DASHBOARD_PASSWORD = process.env.DASHBOARD_PASSWORD || "";
+const DASHBOARD_AUTH_ENABLED = Boolean(
+  DASHBOARD_USERNAME && DASHBOARD_PASSWORD,
+);
 const DISPLAY_NAME = process.env.DASHBOARD_TITLE || "Microsoft Rewards";
 const TIMEZONE = process.env.TZ || "UTC";
 const POLL_MS = Math.max(1000, Number(process.env.POLL_MS || 5000));
@@ -249,31 +254,36 @@ function safeEqual(value, expected) {
   return left.length === right.length && crypto.timingSafeEqual(left, right);
 }
 
-function requestToken(req) {
+function requestBasicCredentials(req) {
   const authorization = req.headers.authorization;
-  if (
-    typeof authorization === "string" &&
-    authorization.startsWith("Bearer ")
-  ) {
-    return authorization.slice(7).trim();
+  if (typeof authorization !== "string") return null;
+
+  const match = authorization.match(/^Basic\s+(.+)$/i);
+  if (!match) return null;
+
+  try {
+    const decoded = Buffer.from(match[1], "base64").toString("utf8");
+    const separator = decoded.indexOf(":");
+    if (separator < 0) return null;
+
+    return {
+      username: decoded.slice(0, separator),
+      password: decoded.slice(separator + 1),
+    };
+  } catch {
+    return null;
   }
-  if (typeof authorization === "string" && authorization.startsWith("Basic ")) {
-    try {
-      const decoded = Buffer.from(authorization.slice(6), "base64").toString(
-        "utf8",
-      );
-      const separator = decoded.indexOf(":");
-      return separator >= 0 ? decoded.slice(separator + 1) : null;
-    } catch {
-      return null;
-    }
-  }
-  const apiKey = req.headers["x-api-key"];
-  return typeof apiKey === "string" ? apiKey.trim() : null;
 }
 
 function isDashboardAuthorized(req) {
-  return !CONTROL_API_TOKEN || safeEqual(requestToken(req), CONTROL_API_TOKEN);
+  if (!DASHBOARD_AUTH_ENABLED) return true;
+
+  const credentials = requestBasicCredentials(req);
+  return (
+    credentials !== null &&
+    safeEqual(credentials.username, DASHBOARD_USERNAME) &&
+    safeEqual(credentials.password, DASHBOARD_PASSWORD)
+  );
 }
 
 function requireDashboardAuth(res) {
@@ -604,9 +614,15 @@ server.listen(PORT, () => {
       "CONTROL_API_TOKEN is empty - this only works if the Control API runs without an API_TOKEN.",
     );
   }
+  if (Boolean(DASHBOARD_USERNAME) !== Boolean(DASHBOARD_PASSWORD)) {
+    log(
+      "warn",
+      "Dashboard authentication is disabled because both DASHBOARD_USERNAME and DASHBOARD_PASSWORD must be set.",
+    );
+  }
   log(
     "info",
-    `Dashboard authentication: ${CONTROL_API_TOKEN ? "enabled (shared Control API token)" : "disabled"}`,
+    `Dashboard authentication: ${DASHBOARD_AUTH_ENABLED ? `enabled (user: ${DASHBOARD_USERNAME})` : "disabled"}`,
   );
   scheduler.init();
   backend.schedule = describeSchedule(scheduler.get());


### PR DESCRIPTION
Add optional `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD` for browser-level authentication. The `CONTROL_API_TOKEN` now exclusively handles dashboard-to-API communication, decoupling the two authentication layers. Dashboard login is enabled only when both credentials are set, allowing flexible security configurations. Update HEALTHCHECK, documentation, and environment variables accordingly.